### PR TITLE
Add NITF 2.1

### DIFF
--- a/aip-processor-api/src/main/proto/processing-service-v2.proto
+++ b/aip-processor-api/src/main/proto/processing-service-v2.proto
@@ -329,12 +329,8 @@ message TiffImage {
 }
 
 message Nitf21Image {
-    int32 width = 1;
-    int32 height = 2;
-    int32 bands = 3;
-
     /** Path to a NITF 2.1 spec image */
-    string path = 4;
+    string path = 1;
 }
 
 message DigitalGlobeMetadata {

--- a/aip-processor-api/src/main/proto/processing-service-v2.proto
+++ b/aip-processor-api/src/main/proto/processing-service-v2.proto
@@ -334,7 +334,7 @@ message Nitf21Image {
     int32 bands = 3;
 
     /** Path to a NITF 2.1 spec image */
-    string path = 3;
+    string path = 4;
 }
 
 message DigitalGlobeMetadata {

--- a/aip-processor-api/src/main/proto/processing-service-v2.proto
+++ b/aip-processor-api/src/main/proto/processing-service-v2.proto
@@ -53,6 +53,7 @@ enum ImageFormat {
     PNG = 1;
     TIFF = 2;
     BGR888 = 3;
+    NITF21 = 4;
 }
 
 message ProcessorV2Config {
@@ -276,6 +277,7 @@ message Image {
         PngImage png_image = 2;
         TiffImage tiff_image = 3;
         Bgr888Image bgr_image = 4;
+        Nitf21Image nitf21_image = 5;
     }
 }
 
@@ -323,6 +325,15 @@ message TiffImage {
     int32 height = 2;
 
     /** The path to a TIFF encoded image. */
+    string path = 3;
+}
+
+message Nitf21Image {
+    int32 width = 1;
+    int32 height = 2;
+    int32 bands = 3;
+
+    /** Path to a NITF 2.1 spec image */
     string path = 3;
 }
 

--- a/changelog/@unreleased/pr-67.v2.yml
+++ b/changelog/@unreleased/pr-67.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add support for processors which accept NITF 2.1 formatted imagery.
+  links:
+  - https://github.com/palantir/aip-processor-api/pull/67


### PR DESCRIPTION
NITF 2.1 is a common imagery standard. Processors may need to operate reading NITF imagery, and potentially make direct use of its various segments.

A couple of tidbits on NITFs:
* They have a variety of _segment_, of different types (image, data, text, labels)
* Imagery segments can have a variety of _bands_. Usually 1-3 bands are quite common
* NITFs can have a set of _Tagged Record Extensions_ (TREs), effectively headers. The total number of headers is finite but large (several 100's)

This PR does not attempt to parse TREs or otherwise inspect NITFs and extract metadata, instead it simply provides an interface for NITFs to be sent directly to a processor which knows how to work with them.