### PR TITLE
Remove incubating messages from API

### DIFF
--- a/aip-processor-api/src/main/proto/processing-service-v2.proto
+++ b/aip-processor-api/src/main/proto/processing-service-v2.proto
@@ -140,8 +140,6 @@ message Inference {
     oneof inference {
         BoundingBox box = 2;
         BoundingPolygon polygon = 3;
-        GeoBoundingBox geo_box = 5;
-        GeoBoundingPolygon geo_polygon = 6;
     }
 
     Velocity velocity = 4;
@@ -177,26 +175,8 @@ message BoundingBox {
     repeated Classification classifications = 3;
 }
 
-/*
- * A bounding box defined by a GeoCoordinate pair.
- */
-message GeoBoundingBox {
-    /** Upper left lat/long */
-    GeoCoordinate c0 = 1;
-    
-    /** Lower right lat/long */
-    GeoCoordinate c1 = 2;
-    
-    repeated Classification classifications = 3;
-}
-
 message BoundingPolygon {
     Polygon polygon = 1;
-    repeated Classification classifications = 2;
-}
-
-message GeoBoundingPolygon {
-    GeoPolygon polygon = 1;
     repeated Classification classifications = 2;
 }
 

--- a/changelog/@unreleased/pr-122.v2.yml
+++ b/changelog/@unreleased/pr-122.v2.yml
@@ -1,0 +1,10 @@
+type: improvement
+improvement:
+  description: |-
+    Remove incubating messages from API
+
+    This PR removes the GeoBoundingBox and GeoBoundingPolygon from the API. It's been decided that generally processors should return coordinates in pixel-space, and it is up to a separate component to map pixel coordinates to geodetic coordinates for mapping purposes.
+
+    These message types were added in an incubating fashion and it is not expected that they are being used or will cause widespread breakages.
+  links:
+  - https://github.com/palantir/aip-processor-api/pull/122

--- a/changelog/@unreleased/pr-122.v2.yml
+++ b/changelog/@unreleased/pr-122.v2.yml
@@ -1,10 +1,6 @@
 type: improvement
 improvement:
   description: |-
-    Remove incubating messages from API
-
-    This PR removes the GeoBoundingBox and GeoBoundingPolygon from the API. It's been decided that generally processors should return coordinates in pixel-space, and it is up to a separate component to map pixel coordinates to geodetic coordinates for mapping purposes.
-
-    These message types were added in an incubating fashion and it is not expected that they are being used or will cause widespread breakages.
+    Remove incubating GeoBoundingBox and GeoBoundingPolygon messages from API.
   links:
   - https://github.com/palantir/aip-processor-api/pull/122


### PR DESCRIPTION
This PR removes the GeoBoundingBox and GeoBoundingPolygon from the API. It's been decided that generally processors should return coordinates in pixel-space, and it is up to a separate component to map pixel coordinates to geodetic coordinates for mapping purposes.

These message types were added in an incubating fashion and it is not expected that they are being used or will cause widespread breakages.