### PR TITLE
Publish to tarball instead of jar

### DIFF
--- a/aip-processor-api/build.gradle
+++ b/aip-processor-api/build.gradle
@@ -16,7 +16,11 @@
 
 apply plugin: 'java-library'
 apply plugin: 'com.google.protobuf'
-apply plugin: 'com.palantir.external-publish-jar'
+apply plugin: 'com.palantir.external-publish-dist'
+
+distTar {
+    compression = Compression.GZIP
+}
 
 dependencies {
     api 'com.google.protobuf:protobuf-java'

--- a/aip-processor-api/build.gradle
+++ b/aip-processor-api/build.gradle
@@ -19,6 +19,8 @@ apply plugin: 'com.google.protobuf'
 apply plugin: 'com.palantir.external-publish-dist'
 
 task distTar(type: Tar) {
+    from ('src/main/proto/')
+    include('*')
 }
 
 dependencies {

--- a/aip-processor-api/build.gradle
+++ b/aip-processor-api/build.gradle
@@ -18,8 +18,7 @@ apply plugin: 'java-library'
 apply plugin: 'com.google.protobuf'
 apply plugin: 'com.palantir.external-publish-dist'
 
-distTar {
-    compression = Compression.GZIP
+task distTar(type: Tar) {
 }
 
 dependencies {

--- a/changelog/@unreleased/pr-135.v2.yml
+++ b/changelog/@unreleased/pr-135.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Publish to tarball instead of jar. This repo contains proto files for consumption, so it's best to publish it as a tarball.
+  links:
+  - https://github.com/palantir/aip-processor-api/pull/135

--- a/readme.md
+++ b/readme.md
@@ -22,4 +22,3 @@ License
 -------
 This repository is licensed under the Apache 2.0 License (https://www.apache.org/licenses/LICENSE-2.0).
 
-


### PR DESCRIPTION
This repo contains proto files for consumption, so it's best to publish it as a tarball.

Running `./gradlew :aip-processor-api:publish` now produces a tar containing the following two files:
- `processing-service-v2.proto`
- `configuration-service.proto`

The tarball is just about 20K, so GZIP compression isn't really necessary.