### PR TITLE
Add jar publishing

### DIFF
--- a/aip-processor-api/build.gradle
+++ b/aip-processor-api/build.gradle
@@ -16,6 +16,7 @@
 
 apply plugin: 'java-library'
 apply plugin: 'com.google.protobuf'
+apply plugin: 'com.palantir.external-publish-jar'
 apply plugin: 'com.palantir.external-publish-dist'
 
 task distTar(type: Tar) {

--- a/changelog/@unreleased/pr-149.v2.yml
+++ b/changelog/@unreleased/pr-149.v2.yml
@@ -1,0 +1,8 @@
+type: feature
+feature:
+  description: |-
+    Add jar publishing
+
+    The newly open sourced `aip-orchestrator` repository requires the generated source and classes from this repository. It used to publish an all-inclusive jar, but was recently updated to publish only a tarball for use with the AIP SDK. However, publishing a jar would also be helpful (and required) for the `aip-orchestrator` now.
+  links:
+  - https://github.com/palantir/aip-processor-api/pull/149


### PR DESCRIPTION
The newly open sourced `aip-orchestrator` repository requires the generated source and classes from this repository. It used to publish an all-inclusive jar, but was recently updated to publish only a tarball for use with the AIP SDK. However, publishing a jar would also be helpful (and required) for the `aip-orchestrator` now.

I tested this by running `./gradlew :aip-processor-api:jar` and verifying that it generated a jar file. I am hoping that the external-publish plugin automatically picks up on this, in addition to the tarball. Wasn't able to test that locally due to lack of signing keys.